### PR TITLE
change output to CSV, fixes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Contents:
 - [Requirements](#requirements)
 - [Building](#building)
 - [Running](#running)
+  - [Options](#options)
 - [License](#license)
 
 ## Requirements
@@ -49,7 +50,21 @@ For example:
 motion-search input.yuv -W=1920 -H=1080 stats.txt
 ```
 
-The input file can be a `.yuv` or `.y4m` file.
+The input file must be a `.yuv` or `.y4m` file.
+
+The output file will be a CSV file containing the following columns:
+
+- `picNum`: picture number
+- `picType`: picture type (I, P, B)
+- `count_I`: number of I blocks
+- `count_P`: number of P blocks
+- `count_B`: number of B blocks
+- `error`: mean squared error
+- `bits`: number of bits estimated
+
+The tool will print extra information to stderr, such as the number of frames processed, per-GOP stats, and total algorithm execution time.
+
+### Options
 
 You can use `-g` to control GOP size (default 150), `-n` to control
 number of frames to read (default is to read all) and `-b` to control

--- a/motion_search/ComplexityAnalyzer.cpp
+++ b/motion_search/ComplexityAnalyzer.cpp
@@ -38,13 +38,13 @@ ComplexityAnalyzer::ComplexityAnalyzer(IVideoSequenceReader *reader,
   const size_t numItems = (size_t)(stride_MB) * (padded_height_MB);
   m_mses = memory::AlignedAlloc<int>(numItems);
   if (m_mses == NULL) {
-    printf("Not enough memory (%zu bytes) for %s\n", numItems * sizeof(int),
+    fprintf(stderr, "Not enough memory (%zu bytes) for %s\n", numItems * sizeof(int),
            "m_mses");
     exit(-1);
   }
   m_MB_modes = memory::AlignedAlloc<unsigned char>(numItems);
   if (m_MB_modes == NULL) {
-    printf("Not enough memory (%zu bytes) for %s\n",
+    fprintf(stderr, "Not enough memory (%zu bytes) for %s\n",
            numItems * sizeof(unsigned char), "m_MB_modes");
     exit(-1);
   }
@@ -99,7 +99,7 @@ void ComplexityAnalyzer::process_i_picture(YUVFrame *pict) {
   m_GOP_error += error;
   add_info(m_pReader->count(), 'I', error, m_pPmv->count_I(), 0, 0, bits);
   // for debugging
-  // printf("Frame %6d (I), I:%6d, P:%6d, B:%6d, MSE = %9d, bits =
+  // fprintf(stderr, "Frame %6d (I), I:%6d, P:%6d, B:%6d, MSE = %9d, bits =
   // %7d\n",pict->pos()+1,m_pPmv->count_I(),0,0,error,bits);
   pict->boundaryExtend();
 }
@@ -118,7 +118,7 @@ void ComplexityAnalyzer::process_p_picture(YUVFrame *pict, YUVFrame *ref) {
   add_info(m_pReader->count(), 'P', error, m_pPmv->count_I(), m_pPmv->count_P(),
            0, bits);
   // for debugging
-  // printf("Frame %6d (P), I:%6d, P:%6d, B:%6d, MSE = %9d, bits =
+  // fprintf(stderr, "Frame %6d (P), I:%6d, P:%6d, B:%6d, MSE = %9d, bits =
   // %7d\n",pict->pos()+1,m_pPmv->count_I(),m_pPmv->count_P(),0,error,bits);
   pict->boundaryExtend();
 }
@@ -138,7 +138,7 @@ void ComplexityAnalyzer::process_b_picture(YUVFrame *pict, YUVFrame *fwdref,
   add_info(m_pReader->count() - (backref->pos() - pict->pos()), 'B', error,
            m_pPmv->count_I(), m_pPmv->count_P(), m_pPmv->count_B(), bits);
   // for debugging
-  // printf("Frame %6d (B), I:%6d, P:%6d, B:%6d, MSE = %9d, bits =
+  // fprintf(stderr, "Frame %6d (B), I:%6d, P:%6d, B:%6d, MSE = %9d, bits =
   // %7d\n",pict->pos()+1,m_pPmv->count_I(),m_pPmv->count_P(),m_pPmv->count_B(),error,bits);
 }
 
@@ -149,11 +149,11 @@ void ComplexityAnalyzer::analyze() {
   try {
     while (m_num_frames > 0 ? m_pReader->count() < m_num_frames
                             : !m_pReader->eof()) {
-      printf("picture #%d\r", m_pReader->count() - 1);
+      fprintf(stderr, "Picture count: %d\r", m_pReader->count() - 1);
 
       if ((m_pReader->count() % m_GOP_size) == 0) {
         if (m_pReader->count()) {
-          printf("GOP: %3d, GOP-bits = %d\n", m_GOP_count, m_GOP_bits);
+          fprintf(stderr, "GOP: %d, GOP-bits: %d\n", m_GOP_count, m_GOP_bits);
           m_GOP_count++;
         }
         m_GOP_error = 0;
@@ -181,11 +181,11 @@ void ComplexityAnalyzer::analyze() {
       }
     }
   } catch (EOFException &e) {
-    printf("\n%s\n", e.what());
+    fprintf(stderr, "\n%s\n", e.what());
   }
 
   if (m_pReorderedInfo != NULL)
     m_info.push_back(m_pReorderedInfo);
 
-  printf("Processed %d frames\n", m_pReader->count());
+  fprintf(stderr, "Processed frames: %d\n", m_pReader->count());
 }

--- a/motion_search/MotionVectorField.cpp
+++ b/motion_search/MotionVectorField.cpp
@@ -20,14 +20,14 @@ MotionVectorField::MotionVectorField(const DIM dim, int stride,
 
   m_pMVs = memory::AlignedAlloc<MV>(m_num_blocks);
   if (m_pMVs == NULL) {
-    printf("Not enough memory (%zu bytes) for motion vectors\n",
+    fprintf(stderr, "Not enough memory (%zu bytes) for motion vectors\n",
            m_num_blocks * sizeof(MV));
     exit(-1);
   }
 
   m_pSADs = memory::AlignedAlloc<int>(m_num_blocks);
   if (m_pSADs == NULL) {
-    printf("Not enough memory (%zu bytes) for SADs\n",
+    fprintf(stderr, "Not enough memory (%zu bytes) for SADs\n",
            m_num_blocks * sizeof(int));
     exit(-1);
   }

--- a/motion_search/YUVFrame.cpp
+++ b/motion_search/YUVFrame.cpp
@@ -22,7 +22,7 @@ YUVFrame::YUVFrame(IVideoSequenceReader *rdr)
 
   m_pFrame = memory::AlignedAlloc<uint8_t>(frame_size);
   if (m_pFrame == NULL) {
-    printf("Not enough memory (%zu bytes) for YUVFrame\n", frame_size);
+    fprintf(stderr, "Not enough memory (%zu bytes) for YUVFrame\n", frame_size);
     exit(-1);
   }
 


### PR DESCRIPTION
Choose CSV as default output format.

Move all output to stderr to allow us to use stdout for piping later on.

Harmonize stderr output format to make it easier to parse, too.